### PR TITLE
docs(install): fix install methods [PLAT-459]

### DIFF
--- a/.github/workflows/install.test.yml
+++ b/.github/workflows/install.test.yml
@@ -1,12 +1,15 @@
 name: Install Harness
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
   push:
     branches:
-      - "plat-459/fix-install-methods" # for testing CI
+      - "main"
 
-  # schedule:
-  #   - cron: "0 0 * * *" # every day at midnight
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight (utc)
 
 jobs:
   install-with-brew:
@@ -24,6 +27,7 @@ jobs:
       - name: Install Harness (with curl)
         run: curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s
 
+      # this should be `manifest-cli`! `manifest` is deprecated now.
       - name: Verify installation
         run: manifest --version
           

--- a/.github/workflows/install.test.yml
+++ b/.github/workflows/install.test.yml
@@ -1,0 +1,69 @@
+name: Install Harness
+
+on:
+  push:
+    branches:
+      - "main"
+      - "plat-459/fix-install-methods"
+
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+
+jobs:
+  install-with-brew:
+    runs-on: macos-latest
+    steps:
+      - name: Install Harness (with brew)
+        run: brew install manifest-cyber/tap/manifest-cli
+      
+      - name: Verify installation
+        run: manifest-cli --version
+
+  install-with-curl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Harness (with curl)
+        run: curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s
+
+      - name: Verify installation
+        run: manifest-cli --version
+          
+  install-with-apt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Harness (with apt sources)
+        run: |
+          echo "deb [trusted=yes] https://manifest.fury.io/apt/ /" > /etc/apt/sources.list.d/fury.list
+          sudo apt update
+          sudo apt install manifest-cli
+
+      - name: Verify installation
+        run: manifest-cli --version
+
+  install-with-yum:
+    runs-on: ubuntu-latest
+    container:
+      image: amazonlinux:2
+    steps:
+      - name: Install Harness (with yum)
+        run: |
+          echo '[fury]
+          name=Manifest Cyber
+          baseurl=https://manifest.fury.io/yum/
+          enabled=1
+          gpgcheck=0' | sudo tee /etc/yum.repos.d/manifest-cyber.repo
+          sudo yum install manifest-cli
+
+      - name: Verify installation
+        run: manifest-cli --version
+
+  install-with-scoop:
+    runs-on: windows-latest
+    steps:
+      - name: Install Harness (with scoop)
+        run: |
+          scoop bucket add manifest-cli https://github.com/manifest-cyber/scoop-bucket.git
+          scoop install manifest-cli
+
+      - name: Verify installation
+        run: manifest-cli --version

--- a/.github/workflows/install.test.yml
+++ b/.github/workflows/install.test.yml
@@ -3,11 +3,10 @@ name: Install Harness
 on:
   push:
     branches:
-      - "main"
-      - "plat-459/fix-install-methods"
+      - "plat-459/fix-install-methods" # for testing CI
 
-  schedule:
-    - cron: "0 0 * * *" # every day at midnight
+  # schedule:
+  #   - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   install-with-brew:
@@ -26,7 +25,7 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s
 
       - name: Verify installation
-        run: manifest-cli --version
+        run: manifest --version
           
   install-with-apt:
     runs-on: ubuntu-latest
@@ -34,8 +33,8 @@ jobs:
       - name: Install Harness (with apt sources)
         run: |
           echo "deb [trusted=yes] https://manifest.fury.io/apt/ /" > /etc/apt/sources.list.d/fury.list
-          sudo apt update
-          sudo apt install manifest-cli
+          apt update -y
+          apt install -y manifest-cli
 
       - name: Verify installation
         run: manifest-cli --version
@@ -51,8 +50,8 @@ jobs:
           name=Manifest Cyber
           baseurl=https://manifest.fury.io/yum/
           enabled=1
-          gpgcheck=0' | sudo tee /etc/yum.repos.d/manifest-cyber.repo
-          sudo yum install manifest-cli
+          gpgcheck=0' | tee /etc/yum.repos.d/manifest-cyber.repo
+          yum install -y manifest-cli
 
       - name: Verify installation
         run: manifest-cli --version
@@ -60,10 +59,22 @@ jobs:
   install-with-scoop:
     runs-on: windows-latest
     steps:
+      - name: Install Scoop
+        run: |
+          $env:SCOOP_CONFIRM='true'
+          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+          irm get.scoop.sh | iex
+          # Add Scoop to the PATH for all subsequent steps
+          $scoopPath = "$env:USERPROFILE\scoop\shims"
+          echo "Adding $scoopPath to PATH"
+          $env:PATH += ";$scoopPath"
+      
       - name: Install Harness (with scoop)
         run: |
+          $env:SCOOP_CONFIRM='true'
           scoop bucket add manifest-cli https://github.com/manifest-cyber/scoop-bucket.git
           scoop install manifest-cli
 
       - name: Verify installation
-        run: manifest-cli --version
+        run: |
+          manifest-cli --version

--- a/.github/workflows/install.test.yml
+++ b/.github/workflows/install.test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Install Harness (with apt sources)
         run: |
-          echo "deb [trusted=yes] https://manifest.fury.io/apt/ /" > /etc/apt/sources.list.d/fury.list
+          echo "deb [trusted=yes] https://manifest.fury.io/apt/ /" | sudo tee /etc/apt/sources.list.d/fury.list
           apt update -y
           apt install -y manifest-cli
 
@@ -64,17 +64,17 @@ jobs:
           $env:SCOOP_CONFIRM='true'
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
           irm get.scoop.sh | iex
-          # Add Scoop to the PATH for all subsequent steps
           $scoopPath = "$env:USERPROFILE\scoop\shims"
           echo "Adding $scoopPath to PATH"
           $env:PATH += ";$scoopPath"
       
       - name: Install Harness (with scoop)
         run: |
-          $env:SCOOP_CONFIRM='true'
+          $env:PATH += ";$env:USERPROFILE\scoop\shims"
           scoop bucket add manifest-cli https://github.com/manifest-cyber/scoop-bucket.git
           scoop install manifest-cli
 
       - name: Verify installation
         run: |
+          $env:PATH += ";$env:USERPROFILE\scoop\shims"
           manifest-cli --version

--- a/.github/workflows/install.test.yml
+++ b/.github/workflows/install.test.yml
@@ -30,14 +30,18 @@ jobs:
   install-with-apt:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Harness (with apt sources)
+      - name: Add Manifest Fury repository
         run: |
           echo "deb [trusted=yes] https://manifest.fury.io/apt/ /" | sudo tee /etc/apt/sources.list.d/fury.list
-          apt update -y
-          apt install -y manifest-cli
+          sudo apt update -y
+          
+      - name: Install Harness (with apt)
+        run: |
+          sudo apt install -y manifest-cli
 
       - name: Verify installation
-        run: manifest-cli --version
+        run: |
+          manifest-cli --version
 
   install-with-yum:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Manifest CLI
 
-## Notice
-
-Starting _January 31st, 2024_ all Manifest CLI releases will be named `manifest-cli` and changed away from the current name: `manifest`.
-Users will need to change the name anywhere that `manifest` is being called (e.g. pipelines or scripts) to get the latest Manifest CLI functionality.
+> [!NOTE] 
+> Starting _January 31st, 2024_ all Manifest CLI releases will be named `manifest-cli` and changed away from the current name: `manifest`.
+> Users will need to change the name anywhere that `manifest` is being called (e.g. pipelines or scripts) to get the latest Manifest CLI functionality.
 
 ## Overview
 
@@ -52,41 +51,6 @@ sudo apt install manifest-cli
 ```bash
 brew install manifest-cyber/tap/manifest-cli
 ```
-</details>
-
-<details>
-<summary>Docker</summary>
-	
-```bash
-docker run --rm --privileged \
-  -v $PWD:/go/src/github.com/user/repo \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -w /go/src/github.com/user/repo \
-  -e GITHUB_TOKEN \
-  -e DOCKER_USERNAME \
-  -e DOCKER_PASSWORD \
-  -e DOCKER_REGISTRY \
-  -e MANIFEST_API_KEY \
-manifest-cyber/cli merge
-```
-</details>
-
-<details>
-<summary>Go</summary>
-
-```go
-go get github.com/manifest-cyber/cli
-```
-
-</details>
-
-<details>
-<summary>Snapcraft</summary>
-
-```bash
-sudo snap install --classic manifest-cli
-```
-
 </details>
 
 <details>


### PR DESCRIPTION
This PR, 

- Removes `docker`, `go`, and `snap` installation method from README.md as they do not work
- Adds test harness, so we can get notified if something stops working!

Updated README (rendered) - https://github.com/manifest-cyber/cli/blob/plat-459/fix-install-methods/README.md