### PR TITLE
docs: document snapshot publishing and previously-undocumented publish flags

### DIFF
--- a/ARGUMENTS.md
+++ b/ARGUMENTS.md
@@ -149,6 +149,15 @@ Publish SBOM(s) to the Manifest platform.
 |------|-------|------|---------|-------------|
 | `--deactivate-older` | `-d` | bool | `false` | Mark previous versions of this asset as inactive when publishing this SBOM |
 
+### Snapshots
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--snapshot-label` | - | string | - | Label identifying the snapshot this SBOM belongs to, e.g. an environment name or release tag (required with `--snapshot-timestamp`) |
+| `--snapshot-timestamp` | - | string | - | RFC3339 timestamp the snapshot represents, with an explicit UTC offset, e.g. `2024-01-15T10:00:00Z` (required with `--snapshot-label`) |
+
+> **Note:** Pass both flags together to enable snapshot mode. The timestamp must be RFC3339 with a UTC offset, must not be in the future, and must not be more than 7 days in the past. See [Publishing Snapshots](README.md#publishing-snapshots) in the README for what snapshot mode does.
+
 ### VDR (Vulnerability Disclosure Report)
 
 | Flag | Short | Type | Default | Description |

--- a/ARGUMENTS.md
+++ b/ARGUMENTS.md
@@ -128,6 +128,8 @@ Publish SBOM(s) to the Manifest platform.
 | `--relationship` | - | string | `first` | Set the relationship of the SBOM(s) |
 | `--hidden` | - | bool | `false` | Hide assets and components |
 | `--ignore-validation` | `-s` | bool | `false` | Ignore validation of the SBOM(s) |
+| `--name` | `-n` | string | - | Override the asset/SBOM document name written to the SBOM root component (overrides the value already in the SBOM) |
+| `--version` | - | string | - | Override the asset/SBOM document version written to the SBOM root component (overrides the value already in the SBOM) |
 
 ### Product & Labeling
 
@@ -148,6 +150,8 @@ Publish SBOM(s) to the Manifest platform.
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--deactivate-older` | `-d` | bool | `false` | Mark previous versions of this asset as inactive when publishing this SBOM |
+| `--deactivate-label` | - | []string | - | Restrict `--deactivate-older` to assets carrying any of these labels (repeatable; requires `--deactivate-older`) |
+| `--replace-in-product` | - | bool | `false` | After upload, replace the asset's prior version in the product inventory (requires `--product-id`) |
 
 ### Snapshots
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,45 @@ The same arguments available for the `sbom` command are available for `merge`.
 manifest-cli merge --input-format=cyclonedx --name=my-app scm-sbom.json image-scm.json
 ```
 
+## Publishing Snapshots
+
+A snapshot tells the Manifest platform that a group of SBOMs represents the complete state of an environment or release at a single point in time. When you publish in snapshot mode, the platform runs a deactivation sweep after the upload completes: assets that share the snapshot label but were last seen *before* the snapshot timestamp are marked inactive. This keeps your inventory in sync with what is actually deployed, without you having to deactivate stale assets by hand.
+
+Common uses are reconciling a live environment (e.g. `production`, `staging`) on each deploy, or marking everything from a prior release tag inactive when a new release ships.
+
+Snapshot mode is enabled by passing **both** of these flags together:
+
+- `--snapshot-label <label>`: identifies the snapshot the SBOM belongs to, such as an environment name or release tag (e.g. `production`, `v1.4.0`).
+- `--snapshot-timestamp <timestamp>`: an RFC3339 timestamp with an explicit UTC offset (e.g. `2024-01-15T10:00:00Z`). This is the moment the snapshot represents and the boundary the deactivation sweep uses.
+
+The CLI validates the timestamp before making any API call. It must be RFC3339 with an explicit UTC offset (a trailing `Z` for UTC, or an offset like `-05:00`), must not be in the future, and must not be more than 7 days in the past. Passing one flag without the other fails validation; passing neither publishes the SBOM normally with no sweep.
+
+These flags are available on the `publish`, `sbom --publish`, and `merge --publish` commands.
+
+```bash
+# Publish an existing SBOM as part of the production snapshot
+manifest-cli publish sbom.json \
+  --snapshot-label production \
+  --snapshot-timestamp 2024-01-15T10:00:00Z
+
+# Generate and publish in one step, tagged to a release snapshot
+manifest-cli sbom ./ -f sbom.json --publish \
+  --snapshot-label v1.4.0 \
+  --snapshot-timestamp 2024-01-15T10:00:00Z
+```
+
+In CI you will usually generate the timestamp at publish time:
+
+```bash
+export MANIFEST_API_KEY=your-api-token
+SNAPSHOT_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+manifest-cli publish sbom.json \
+  --snapshot-label production \
+  --snapshot-timestamp "$SNAPSHOT_TS"
+```
+
+> **Note:** The deactivation sweep only runs when snapshot mode is enabled. Snapshot mode and `--deactivate-older` serve different purposes: `--deactivate-older` deactivates prior versions of the same asset, while snapshots reconcile an entire environment or release against a point in time.
+
 ## (Beta) Generating & Publishing SBOM Attestation
 
 ## Keyless Signing

--- a/README.md
+++ b/README.md
@@ -317,6 +317,38 @@ The same arguments available for the `sbom` command are available for `merge`.
 manifest-cli merge --input-format=cyclonedx --name=my-app scm-sbom.json image-scm.json
 ```
 
+## Deactivating Older Versions
+
+When you publish a new version of an asset, the previous versions stay active by default. Add `--deactivate-older` (`-d`) to mark prior versions of the same asset inactive as part of the same publish, so your inventory reflects only the version you just shipped:
+
+```bash
+export MANIFEST_API_KEY=your-api-token
+manifest-cli publish sbom.json --deactivate-older
+```
+
+By default this deactivates *every* older version of the asset. To narrow it to older versions carrying specific labels, add `--deactivate-label` (repeatable). Each value is matched against the asset's labels, and only matching older versions are deactivated. `--deactivate-label` requires `--deactivate-older`:
+
+```bash
+# Only deactivate older versions labeled "production" or "java"
+manifest-cli publish sbom.json \
+  --deactivate-older \
+  --deactivate-label production \
+  --deactivate-label java
+```
+
+These flags are available on the `publish`, `sbom --publish`, and `merge --publish` commands.
+
+## Replacing an Asset in a Product
+
+When an asset belongs to a product's inventory, `--replace-in-product` swaps the asset's prior version out of that product and puts the version you are publishing in its place, after the upload and vulnerability scan complete. This is useful when a product should track exactly one version of an asset. It requires `--product-id` to identify which product's inventory to update:
+
+```bash
+export MANIFEST_API_KEY=your-api-token
+manifest-cli publish sbom.json \
+  --product-id YOUR_PRODUCT_ID \
+  --replace-in-product
+```
+
 ## Publishing Snapshots
 
 A snapshot tells the Manifest platform that a group of SBOMs represents the complete state of an environment or release at a single point in time. When you publish in snapshot mode, the platform runs a deactivation sweep after the upload completes: assets that share the snapshot label but were last seen *before* the snapshot timestamp are marked inactive. This keeps your inventory in sync with what is actually deployed, without you having to deactivate stale assets by hand.


### PR DESCRIPTION
## Summary

Documents previously-undocumented CLI publish functionality.

**Snapshots**
- README.md: a *Publishing Snapshots* section covering snapshot mode, the paired `--snapshot-label` / `--snapshot-timestamp` flags, the deactivation sweep, timestamp validation rules, and examples.
- ARGUMENTS.md: a *Snapshots* subsection under the Publish Command.

**Other missing publish flags** (existed in the CLI, absent from the reference)
- ARGUMENTS.md Publish Command: adds `--name`, `--version`, `--deactivate-label`, and `--replace-in-product`.

Documentation only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new `manifest-cli publish` flags: `--name` and `--version` for SBOM root overrides, `--deactivate-label` for scoping asset deactivation, and `--replace-in-product` for managing product inventory versions.
  * Introduced "Publishing Snapshots" guide with snapshot-mode semantics, use cases, required flags, validation constraints, example commands, and CI integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->