### PR TITLE
docs: correct version flag, no -v shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Note: CycloneDX released v1.5 on June 25, 2023. Currently, Manifest only provide
 
 `--generator-config`: set path to generator config file (if applicable)
 
-`v`, `--version`: Version of the generated SBOM. Overrides any existing version info.
+`--version`: Version of the generated SBOM. Overrides any existing version info.
 
 `--`: to pass through additional arguments to specific generators, use the `--` separator at the end of the command, followed by any additional arguments.
 


### PR DESCRIPTION
The `--version` flag for SBOM generation has no `-v` shorthand — `-v` is bound to `--verbose`. This removes the inaccurate `v,` prefix from the flag documentation so users don't try to use a shorthand that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI arguments documentation to reflect that the version option now uses only the `--version` flag (removed short alias).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->