### PR TITLE
docs: document the --supplier flag

### DIFF
--- a/ARGUMENTS.md
+++ b/ARGUMENTS.md
@@ -49,6 +49,7 @@ Generate SBOMs from local filesystems or containers.
 | `--output` | `-o` | string | `cyclonedx-json` | SBOM output format: `spdx-json`, `cyclonedx-json` |
 | `--generator-preset` | - | string | `recommended` | Set generator config preset: `recommended`, `none` |
 | `--generator-config` | - | string | - | Path to generator config file (if applicable) |
+| `--supplier` | - | string | - | Supplier (organization) name to set on the root SBOM component and BOM metadata |
 | `--hierarchical` | - | bool | `true` | Perform a hierarchical merge |
 | `--use-tmp-sbom` | - | bool | `true` | Write temporary SBOMs to OS-specific temporary folder and delete after merge |
 | `--keep-clone` | - | bool | `false` | Keep the local git clone once generation is completed |
@@ -212,6 +213,7 @@ Merge two or more SBOMs into a single SBOM.
 | `--name` | - | string | - | Name of merged SBOM document |
 | `--version` | - | string | - | Version of merged SBOM document |
 | `--group` | - | string | - | Group of merged SBOM document |
+| `--supplier` | - | string | - | Supplier (organization) name to set on the root SBOM component and BOM metadata. For SPDX output this sets the package supplier, falling back to `--group` when unset |
 
 ### Signing & Publishing
 
@@ -346,6 +348,17 @@ manifest-cli publish sbom.json \
 manifest-cli generate ./path/to/code \
   --detect-ai \
   --file my-sbom \
+  --output cyclonedx-json
+```
+
+### Generate with a Supplier
+
+```bash
+# Set the supplier on the root component and BOM metadata
+manifest-cli generate ./path/to/code \
+  --name api \
+  --version 1.3.0 \
+  --supplier "Manifest Cyber" \
   --output cyclonedx-json
 ```
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Note: CycloneDX released v1.5 on June 25, 2023. Currently, Manifest only provide
 
 `--generator-config`: set path to generator config file (if applicable)
 
+`--supplier`: Supplier (organization) name to set on the root SBOM component (`metadata.component.supplier`) and the BOM metadata (`metadata.supplier`). For SPDX output this sets the package supplier, falling back to `--group` when unset.
+
 `--version`: Version of the generated SBOM. Overrides any existing version info.
 
 `--`: to pass through additional arguments to specific generators, use the `--` separator at the end of the command, followed by any additional arguments.


### PR DESCRIPTION
Documents the new `--supplier` flag on `generate` and `merge`, added to the CLI in manifest-cli.

## Changes

- `ARGUMENTS.md`: `--supplier` row in the Generate and Merge flag tables, plus a "Generate with a Supplier" example.
- `README.md`: `--supplier` entry in the generate flag list.

The flag sets the supplier on the CycloneDX root component (`metadata.component.supplier`) and the BOM metadata (`metadata.supplier`). For SPDX output it sets the package supplier, falling back to `--group` when unset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new `--supplier` option in CLI commands.
  * Clarified how supplier information is applied to generated and merged SBOM output.
  * Included an example showing how to generate an SBOM with a supplier value.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->