### PR TITLE
docs: document API token scopes per flag and how to find a product ID

### DIFF
--- a/ARGUMENTS.md
+++ b/ARGUMENTS.md
@@ -137,7 +137,7 @@ Publish SBOM(s) to the Manifest platform.
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--product-id` | `-P` | string | - | ID of the product to associate the SBOM(s) with |
+| `--product-id` | `-P` | string | - | ID of the product to associate the SBOM(s) with. Find it in the product's page URL in the Manifest app (the segment between `/product/` and `/overview`, e.g. `.../product/64b8f0a2e1d3c5a7b9f2e4d6/overview`). See [Token Permissions](#token-permissions) |
 | `--asset-label` | - | []string | - | Add labels to the associated asset of the SBOM(s) |
 | `--product-label` | - | []string | - | Add labels to the associated product of the SBOM(s) (requires `--product-id`) |
 
@@ -188,6 +188,20 @@ Publish SBOM(s) to the Manifest platform.
 |------|-------|-------------|------|
 | `--label` | `-l` | `--asset-label` | Use `--asset-label` instead |
 | `--paths` | `-p` | Positional arguments | Use positional arguments instead |
+
+### Token Permissions
+
+The API token passed via `--api-key` (or `MANIFEST_API_KEY`) must carry the scope permission(s) for the flags you use. Grant these when creating the token in the Manifest app.
+
+| Flag / operation | Required scope permission(s) |
+|------|-------------|
+| `--publish` | Generate and upload SBOMs and VEX documents |
+| `--product-id` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--replace-in-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--update-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--download-vdr` | View all SBOMs and VEX documents **and** View asset VDR reports |
+
+> **Note:** The product operations (`--product-id`, `--replace-in-product`, `--update-product`) require a user API token created from the API Tokens page on your profile. They also wait for the upload's vulnerability scan to finish before attaching the asset, which is why they additionally need "View all SBOMs and VEX documents".
 
 ---
 
@@ -308,6 +322,8 @@ Run CRAT reachability assessments or execute CRAT subcommands.
 |------|-------|------|---------|-------------|
 | `--api-key` | `-k` | string | `$MANIFEST_API_KEY` | API key from Manifest App (overrides `MANIFEST_API_KEY` env variable) |
 | `--api-uri` | - | string | `https://api.manifestcyber.com/v1` | URI for the Manifest API (self-hosted, etc environments will want to change this) |
+
+> **Token permissions:** `crat` generates and publishes an SBOM, waits for its vulnerability scan, and downloads the VDR before analyzing reachability, so its `--api-key` (a user API token) needs all three of: Generate and upload SBOMs and VEX documents, View all SBOMs and VEX documents, and View asset VDR reports. The `--llm-api-key` is for the LLM provider (OpenAI/Anthropic) and is unrelated to your Manifest token.
 
 ### Generator Options
 

--- a/ARGUMENTS.md
+++ b/ARGUMENTS.md
@@ -191,17 +191,17 @@ Publish SBOM(s) to the Manifest platform.
 
 ### Token Permissions
 
-The API token passed via `--api-key` (or `MANIFEST_API_KEY`) must carry the scope permission(s) for the flags you use. Grant these when creating the token in the Manifest app.
+The API token passed via `--api-key` (or `MANIFEST_API_KEY`) must have the scope(s) for the flags you use. Enable these when creating the token in the Manifest app (names match the checkboxes on the token creation screen).
 
-| Flag / operation | Required scope permission(s) |
+| Flag / operation | Scope(s) to enable |
 |------|-------------|
-| `--publish` | Generate and upload SBOMs and VEX documents |
-| `--product-id` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--replace-in-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--update-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--download-vdr` | View all SBOMs and VEX documents **and** View asset VDR reports |
+| `--publish` | Manage SBOMs and VEX |
+| `--product-id` | Manage products, Manage assets, and View all pages and data |
+| `--replace-in-product` | Manage products, Manage assets, and View all pages and data |
+| `--update-product` | Manage products, Manage assets, and View all pages and data |
+| `--download-vdr` | View all pages and data |
 
-> **Note:** The product operations (`--product-id`, `--replace-in-product`, `--update-product`) require a user API token created from the API Tokens page on your profile. They also wait for the upload's vulnerability scan to finish before attaching the asset, which is why they additionally need "View all SBOMs and VEX documents".
+> **Note:** Use a user API token created from the API Tokens page on your profile. The product operations (`--product-id`, `--replace-in-product`, `--update-product`) wait for the upload's vulnerability scan to finish before attaching the asset, so they need **View all pages and data** (the read scope) in addition to **Manage products** and **Manage assets**. **View all pages and data** is also what covers `--download-vdr`.
 
 ---
 
@@ -323,7 +323,7 @@ Run CRAT reachability assessments or execute CRAT subcommands.
 | `--api-key` | `-k` | string | `$MANIFEST_API_KEY` | API key from Manifest App (overrides `MANIFEST_API_KEY` env variable) |
 | `--api-uri` | - | string | `https://api.manifestcyber.com/v1` | URI for the Manifest API (self-hosted, etc environments will want to change this) |
 
-> **Token permissions:** `crat` generates and publishes an SBOM, waits for its vulnerability scan, and downloads the VDR before analyzing reachability, so its `--api-key` (a user API token) needs all three of: Generate and upload SBOMs and VEX documents, View all SBOMs and VEX documents, and View asset VDR reports. The `--llm-api-key` is for the LLM provider (OpenAI/Anthropic) and is unrelated to your Manifest token.
+> **Token permissions:** `crat` generates and publishes an SBOM, waits for its vulnerability scan, and downloads the VDR before analyzing reachability, so its `--api-key` (a user API token) needs **Manage SBOMs and VEX** and **View all pages and data** enabled. The `--llm-api-key` is for the LLM provider (OpenAI/Anthropic) and is unrelated to your Manifest token.
 
 ### Generator Options
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Note: CycloneDX released v1.5 on June 25, 2023. Currently, Manifest only provide
 
 `--label`: **[DEPRECATED] use --asset-label instead.** One or more labels to add to the SBOM. If the label does not exist, it will be created then applied to the SBOM. Use a single --label flag with comma delimited values, or multiple --label flag instances.
 
-`--product-id`: Assign an SBOM to a product by providing a product ID. You may create products through the Manifest UI.
+`--product-id`: Assign an SBOM to a product by providing a product ID. You may create products through the Manifest UI. To find a product's ID, open the product in the Manifest app and copy the identifier from the page URL: it is the segment between `/product/` and `/overview` (for example, in `https://app.manifestcyber.com/product/64b8f0a2e1d3c5a7b9f2e4d6/overview` the product ID is `64b8f0a2e1d3c5a7b9f2e4d6`). Only takes effect together with `--publish`, and requires a token carrying the product permissions listed under [API Tokens for Publishing SBOMs](#api-tokens-for-publishing-sboms).
 
 `--active={true|false}`: Whether this SBOM should be marked as Active when uploading, if not present the default of your organization's setting will be used (which is typically `true`).
 
@@ -517,6 +517,20 @@ To create a new token:
     ![Save your token in a secure location](/img3.png)
 
 Remember to protect your API key! Avoid committing it to your source code or printing it as plain text. Instead, use secrets management tools to keep it secure 🧙.
+
+### Scope permissions by flag
+
+The scopes you add in step 2 must cover the flags you intend to use. Grant the permission(s) below for each operation:
+
+| Flag / operation | Required scope permission(s) |
+| --- | --- |
+| `--publish` (upload an SBOM) | Generate and upload SBOMs and VEX documents |
+| `--product-id` (assign an SBOM to a product) | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--replace-in-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--update-product` (reconcile a product to a snapshot) | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
+| `--download-vdr` | View all SBOMs and VEX documents **and** View asset VDR reports |
+
+> **Note:** The product operations (`--product-id`, `--replace-in-product`, `--update-product`) require a user API token created from the API Tokens page on your profile (the flow shown above). These operations also wait for the upload's vulnerability scan to finish before attaching the asset, which is why they additionally need "View all SBOMs and VEX documents".
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -520,17 +520,17 @@ Remember to protect your API key! Avoid committing it to your source code or pri
 
 ### Scope permissions by flag
 
-The scopes you add in step 2 must cover the flags you intend to use. Grant the permission(s) below for each operation:
+The scopes you enable in step 2 must cover the flags you intend to use. Enable the scope(s) below for each operation (names match the checkboxes on the token creation screen):
 
-| Flag / operation | Required scope permission(s) |
+| Flag / operation | Scope(s) to enable |
 | --- | --- |
-| `--publish` (upload an SBOM) | Generate and upload SBOMs and VEX documents |
-| `--product-id` (assign an SBOM to a product) | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--replace-in-product` | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--update-product` (reconcile a product to a snapshot) | Edit product details, Update asset's active/inactive status, **and** View all SBOMs and VEX documents |
-| `--download-vdr` | View all SBOMs and VEX documents **and** View asset VDR reports |
+| `--publish` (upload an SBOM) | Manage SBOMs and VEX |
+| `--product-id` (assign an SBOM to a product) | Manage products, Manage assets, and View all pages and data |
+| `--replace-in-product` | Manage products, Manage assets, and View all pages and data |
+| `--update-product` (reconcile a product to a snapshot) | Manage products, Manage assets, and View all pages and data |
+| `--download-vdr` | View all pages and data |
 
-> **Note:** The product operations (`--product-id`, `--replace-in-product`, `--update-product`) require a user API token created from the API Tokens page on your profile (the flow shown above). These operations also wait for the upload's vulnerability scan to finish before attaching the asset, which is why they additionally need "View all SBOMs and VEX documents".
+> **Note:** Use a user API token created from the API Tokens page on your profile (the flow shown above). The product operations (`--product-id`, `--replace-in-product`, `--update-product`) wait for the upload's vulnerability scan to finish before attaching the asset, so they need **View all pages and data** (the read scope) in addition to **Manage products** and **Manage assets**. **View all pages and data** is also what covers `--download-vdr`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ manifest-cli sbom --asset-label=production --asset-label=java --generator=cdxgen
 #### SBOM Generation with product assignment and labels
 
 ```bash
-manifest-cli sbom --product-id=MY_PRODUCT_ID --product-label=production --product-label=golang --name=my-sbom --version=v1.0.0 --output=spdx-json ./path/to/repo
+manifest-cli sbom --product-id=MY_PRODUCT_ID --product-label=production --product-label=golang --name=my-sbom --version=v1.0.0 --output=spdx-json --publish ./path/to/repo
 ```
 
 #### Generation with specific file and container


### PR DESCRIPTION
## Summary

Documents which Manifest API token scope each CLI flag requires, and how to find a product ID, in the public CLI docs. Derived by tracing every manifest-api call the CLI makes and mapping each endpoint to its permission guard.

### README.md
- New **Scope permissions by flag** table in the "API Tokens for Publishing SBOMs" section.
- Expanded the `--product-id` description with how to find a product ID (copy the ID segment from the product's page URL, e.g. `.../product/<id>/overview`).

### ARGUMENTS.md
- New **Token Permissions** table under the Publish command.
- Product-ID URL hint on the `--product-id` row.
- Note on the `crat` command's token needs (it publishes, polls, and downloads a VDR).

## Scope mapping

| Flag / operation | Required scope permission(s) |
| --- | --- |
| `--publish` | Generate and upload SBOMs and VEX documents |
| `--product-id` / `--replace-in-product` / `--update-product` | Edit product details + Update asset's active/inactive status + View all SBOMs and VEX documents |
| `--download-vdr` | View all SBOMs and VEX documents + View asset VDR reports |
| `crat` | all three of: Generate and upload SBOMs and VEX documents, View all SBOMs and VEX documents, View asset VDR reports |

## Notes
- The product operations poll the SBOM's scan status before attaching the asset, which is why they also need "View all SBOMs and VEX documents".
- The product ID in the docs is a synthetic example ObjectId, not a real one.
- Token wording references user API tokens created from the profile API Tokens page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to find the product ID in the Manifest UI and how it relates to the `--product-id` flag, including that it’s only valid when used with publishing.
  * Expanded token-permission guidance with a new “Token Permissions” section and a scope-by-flag table for publishing and related product operations.
  * Added notes on token requirements, including that product operations depend on vulnerability-scan completion before assets are attached.
  * Included `crat`-specific authentication scope guidance and clarified that `--llm-api-key` is not a Manifest token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->